### PR TITLE
docs: add libsecret per-repo credential setup guide — v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ conventions described in [README.md](README.md#versioning-semver).
 
 ---
 
+## [1.1.1] — 2025-04-30
+
+### Added
+- `docs/libsecret-credential-setup.md`: guide for storing per-repo GitHub PATs
+  using libsecret and `credential.useHttpPath=true` on Linux Mint
+
+---
+
 ## [1.1.0] — 2025-04-29
 
 ### Added
@@ -35,5 +43,6 @@ conventions described in [README.md](README.md#versioning-semver).
 
 ---
 
-[Unreleased]: https://github.com/hervetchoffo/telco-homelab/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/hervetchoffo/telco-homelab/compare/v1.1.1...HEAD
+[1.1.1]: https://github.com/hervetchoffo/telco-homelab/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/hervetchoffo/telco-homelab/releases/tag/v1.1.0

--- a/docs/PROJECT_CONTEXT.md
+++ b/docs/PROJECT_CONTEXT.md
@@ -43,13 +43,20 @@ the correct topology is 1 server + 1 agent. HA is out of scope for Edition 1.
 Versioning (SemVer):
   - MAJOR=1  → Edition 1 (Core Infrastructure)
   - MINOR    → one deliverable milestone (v1.2.0 = HLD document)
-  - PATCH    → fix after a MINOR (v1.2.1)
+  - PATCH    → fix or addition after a MINOR (v1.1.1 = credential guide)
   - -rc.N    → release candidate
   - -final   → last stable of the edition (archive tag)
 
 GitHub workflow:
-  Milestone v1.X.0 → Issues → Branch feat/v1.X.0-<desc>
-  → PR (links AI discussion) → merge → git tag → Release → Milestone closed
+  Issue → Branch feat/v1.X.0-<desc> or fix/v1.X.Y-<desc>
+  → PR (links AI discussion URL) → merge → git tag → Release
+  → Milestone closed → PROJECT_CONTEXT updated
+
+Local credential setup:
+  - Two fine-grained PATs, one per repo, stored in libsecret
+  - credential.useHttpPath=true isolates tokens by full repo path
+  - Both remote URLs embed username: https://hervetchoffo@github.com/...
+  - Guide: docs/libsecret-credential-setup.md
 
 Repository: https://github.com/hervetchoffo/telco-homelab
 
@@ -63,7 +70,8 @@ Repository: https://github.com/hervetchoffo/telco-homelab
 
 | Version | Milestone | Status | Notes |
 |---|---|---|---|
-| `v1.1.0` | Initialize GitHub repository | ✅ Done | README, CHANGELOG, 3 ADRs, PROJECT_CONTEXT, init-repo.sh |
+| `v1.1.0` | Initialize GitHub repository | ✅ Done | README, CHANGELOG, ADR-001/002/003, PROJECT_CONTEXT, init-repo.sh |
+| `v1.1.1` | Credential setup documentation | ✅ Done | docs/libsecret-credential-setup.md, CHANGELOG updated |
 | `v1.2.0` | HLD document & network inventory | 🔲 | |
 | `v1.3.0` | Prepare Raspberry Pi OS (Trixie) | 🔲 | |
 | `v1.4.0` | K3s server on Pi #1 | 🔲 | |
@@ -90,6 +98,8 @@ Repository: https://github.com/hervetchoffo/telco-homelab
 | 2 | Confirm USB disk filesystem (ext4 recommended) | ⚠️ v1.3.0 |
 | 3 | Gitea registry vs Docker Hub for ARM images | ⚠️ v1.9.0 |
 | 4 | Trixie boot path: `/boot/firmware/cmdline.txt` | ✅ Confirmed |
+| 5 | Per-repo PAT isolation via `credential.useHttpPath=true` | ✅ Implemented — see docs/libsecret-credential-setup.md |
+| 6 | PAT expiry: both tokens expire after 90 days — renewal procedure documented | ✅ Documented |
 
 ---
 
@@ -97,12 +107,23 @@ Repository: https://github.com/hervetchoffo/telco-homelab
 
 ### Milestones (GitHub → Issues → Milestones)
 
-Create one milestone per MINOR version:
-`v1.2.0 — HLD document` · `v1.3.0 — Prepare OS` · `v1.4.0 — K3s server`
-`v1.5.0 — K3s agent` · `v1.6.0 — Smoke test` · `v1.7.0 — USB volumes`
-`v1.8.0 — NFS server` · `v1.9.0 — Gitea` · `v1.10.0 — Nginx`
-`v1.11.0 — Tvheadend` · `v1.12.0 — Versioning` · `v1.13.0 — Woodpecker`
-`v1.14.0 — Pipeline` · `v1.15.0 — Monitoring`
+| Milestone | Status |
+|---|---|
+| `v1.1.0 — Initialize GitHub repository` | ✅ Closed |
+| `v1.2.0 — HLD document & network inventory` | 🔲 Create |
+| `v1.3.0 — Prepare Raspberry Pi OS` | 🔲 Create |
+| `v1.4.0 — K3s server on Pi #1` | 🔲 Create |
+| `v1.5.0 — K3s agent on Pi #2` | 🔲 Create |
+| `v1.6.0 — Smoke test` | 🔲 Create |
+| `v1.7.0 — USB volumes` | 🔲 Create |
+| `v1.8.0 — NFS server` | 🔲 Create |
+| `v1.9.0 — Gitea` | 🔲 Create |
+| `v1.10.0 — Nginx` | 🔲 Create |
+| `v1.11.0 — Tvheadend` | 🔲 Create |
+| `v1.12.0 — Versioning` | 🔲 Create |
+| `v1.13.0 — Woodpecker` | 🔲 Create |
+| `v1.14.0 — Pipeline` | 🔲 Create |
+| `v1.15.0 — Monitoring` | 🔲 Create |
 
 ### Projects board columns
 
@@ -114,28 +135,36 @@ Create one milestone per MINOR version:
 
 Format: `[v1.X.0] <Imperative verb> <object>`
 
-| Title | Milestone |
-|---|---|
-| `[v1.1.0] Initialize GitHub repository` | ✅ Done |
-| `[v1.2.0] Write HLD document` | next |
-| `[v1.3.0] Prepare Raspberry Pi OS` | |
-| `[v1.4.0] Install K3s server node` | |
-| `[v1.5.0] Join K3s worker node` | |
-| `[v1.6.0] Validate cluster with smoke test` | |
-| `[v1.7.0] Configure USB persistent volumes` | |
-| `[v1.8.0] Deploy NFS server` | |
-| `[v1.9.0] Deploy Gitea as GitOps source` | |
-| `[v1.10.0] Deploy Nginx with Traefik` | |
-| `[v1.11.0] Deploy Tvheadend with USB tuner` | |
-| `[v1.12.0] Version images and manifests` | |
-| `[v1.13.0] Set up Woodpecker CI runner` | |
-| `[v1.14.0] Build and deploy CI pipeline` | |
-| `[v1.15.0] Add Prometheus and Grafana` | |
+| Title | Milestone | AI session link |
+|---|---|---|
+| `[v1.1.0] Initialize GitHub repository` | ✅ Done | Not shared — contains revoked credential |
+| `[v1.2.0] Write HLD document` | next | To be added after session |
+| `[v1.3.0] Prepare Raspberry Pi OS` | | |
+| `[v1.4.0] Install K3s server node` | | |
+| `[v1.5.0] Join K3s worker node` | | |
+| `[v1.6.0] Validate cluster with smoke test` | | |
+| `[v1.7.0] Configure USB persistent volumes` | | |
+| `[v1.8.0] Deploy NFS server` | | |
+| `[v1.9.0] Deploy Gitea as GitOps source` | | |
+| `[v1.10.0] Deploy Nginx with Traefik` | | |
+| `[v1.11.0] Deploy Tvheadend with USB tuner` | | |
+| `[v1.12.0] Version images and manifests` | | |
+| `[v1.13.0] Set up Woodpecker CI runner` | | |
+| `[v1.14.0] Build and deploy CI pipeline` | | |
+| `[v1.15.0] Add Prometheus and Grafana` | | |
 
 ---
 
 ## Session workflow
 
-**End of session:** mark milestone ✅, note decisions, commit `docs: update PROJECT_CONTEXT after v1.X.0`
+### End of session
+1. Mark completed milestone ✅ in the status table
+2. Note decisions made, blockers hit, files produced
+3. Update open decisions table
+4. Commit: `docs: update PROJECT_CONTEXT after v1.X.Y`
 
-**Start of session:** paste briefing block + updated status rows + `"Today's goal: v1.X.0 — [title]"`
+### Start of next session
+1. Copy the **Briefing block** above
+2. Paste updated status rows into the `CURRENT STATUS` section
+3. Append: `"Today's goal: milestone v1.X.0 — [title]"`
+4. After session: get share link from Claude and add to discussion table above

--- a/docs/libsecret-credential-setup.md
+++ b/docs/libsecret-credential-setup.md
@@ -1,0 +1,274 @@
+# Storing Per-Repository GitHub PATs with libsecret on Linux Mint
+
+> **Version:** v1.1.1
+> **Status:** Implemented
+
+This guide explains how to securely store two different GitHub Personal Access Tokens (PATs)
+in **libsecret** on Linux Mint, so that Git automatically uses the correct token per repository —
+without mixing them up.
+
+---
+
+## Context
+
+This setup was introduced as part of the `telco-homelab` security baseline (`v1.1.1`).
+Two fine-grained PATs are configured:
+
+| Token name | Scoped to | Permissions |
+|---|---|---|
+| `telco-homelab-local` | `hervetchoffo/telco-homelab` | Contents R/W, Metadata R, Pull requests R/W |
+| `measure-dynamics-test-local` | `hervetchoffo/measure-dynamics-test` | Contents R/W, Metadata R, Pull requests R/W |
+
+---
+
+## The problem: Git defaults to host-only credential matching
+
+By default, Git stores HTTPS credentials keyed by **host only**:
+
+```
+host=github.com
+```
+
+This means both repositories would share the same credential — whichever token was
+stored last would be used for all GitHub repos. That is not acceptable when each repo
+has its own scoped PAT.
+
+The solution is `credential.useHttpPath=true`, which tells Git to key credentials by
+**host + full repository path**:
+
+```
+host=github.com
+path=hervetchoffo/telco-homelab
+```
+
+```
+host=github.com
+path=hervetchoffo/measure-dynamics-test
+```
+
+These are stored and retrieved as two completely separate keyring entries.
+
+---
+
+## Prerequisites
+
+- Linux Mint (GNOME keyring available)
+- Git installed
+- `libsecret` helper available at:
+  `/usr/share/doc/git/contrib/credential/libsecret/git-credential-libsecret`
+- Both repos accessed over **HTTPS** (not SSH)
+- One fine-grained GitHub PAT per repository
+
+---
+
+## Step 1 — Confirm HTTPS remotes
+
+Verify both repos use HTTPS with the username embedded in the URL:
+
+```bash
+cd ~/Dropbox/Github/telco-homelab
+git remote -v
+# origin  https://hervetchoffo@github.com/hervetchoffo/telco-homelab.git
+
+cd ~/Dropbox/Github/measure-dynamics-test
+git remote -v
+# origin  https://hervetchoffo@github.com/hervetchoffo/measure-dynamics-test.git
+```
+
+If the username is missing from a remote URL, add it:
+
+```bash
+git remote set-url origin https://hervetchoffo@github.com/hervetchoffo/<repo>.git
+```
+
+---
+
+## Step 2 — Confirm the libsecret helper exists
+
+```bash
+ls /usr/share/doc/git/contrib/credential/libsecret/git-credential-libsecret
+```
+
+If missing, build it:
+
+```bash
+sudo apt update
+sudo apt install -y libsecret-1-0 libsecret-1-dev libglib2.0-dev make gcc
+cd /usr/share/doc/git/contrib/credential/libsecret/
+sudo make
+```
+
+---
+
+## Step 3 — Remove any local credential helpers
+
+If either repo has a local `credential.helper` set (from a previous setup attempt),
+remove it so the global config takes over cleanly:
+
+```bash
+cd ~/Dropbox/Github/telco-homelab
+git config --unset credential.helper
+
+cd ~/Dropbox/Github/measure-dynamics-test
+git config --unset credential.helper
+```
+
+No output is normal. If the command returns
+`error: no such key`, the local helper was never set — that is fine.
+
+---
+
+## Step 4 — Configure Git globally
+
+Set the libsecret helper and enable per-repo path matching globally:
+
+```bash
+git config --global credential.helper \
+  /usr/share/doc/git/contrib/credential/libsecret/git-credential-libsecret
+
+git config --global credential.useHttpPath true
+```
+
+Verify:
+
+```bash
+git config --global --list | grep credential
+```
+
+Expected output:
+
+```
+credential.helper=/usr/share/doc/git/contrib/credential/libsecret/git-credential-libsecret
+credential.usehttppath=true
+```
+
+---
+
+## Step 5 — Clear any old generic GitHub credential
+
+Remove any previously stored credential that was keyed by host only:
+
+```bash
+secret-tool clear service git host github.com
+```
+
+No output is normal.
+
+---
+
+## Step 6 — Store the PAT for `telco-homelab`
+
+```bash
+cd ~/Dropbox/Github/telco-homelab
+git fetch
+```
+
+When prompted:
+
+```
+Username for 'https://hervetchoffo@github.com': hervetchoffo
+Password for 'https://hervetchoffo@github.com': <paste telco-homelab PAT>
+```
+
+Git stores this token in libsecret keyed to `github.com/hervetchoffo/telco-homelab`.
+
+---
+
+## Step 7 — Store the PAT for `measure-dynamics-test`
+
+```bash
+cd ~/Dropbox/Github/measure-dynamics-test
+git fetch
+```
+
+When prompted:
+
+```
+Username for 'https://hervetchoffo@github.com': hervetchoffo
+Password for 'https://hervetchoffo@github.com': <paste measure-dynamics-test PAT>
+```
+
+Git stores this token in libsecret keyed to `github.com/hervetchoffo/measure-dynamics-test`.
+
+---
+
+## Step 8 — Verify per-repo credential resolution
+
+### Method A — Normal Git operation (recommended)
+
+Run `git fetch` inside each repo. If it completes without prompting, the correct PAT
+is stored and working:
+
+```bash
+cd ~/Dropbox/Github/telco-homelab && git fetch
+cd ~/Dropbox/Github/measure-dynamics-test && git fetch
+```
+
+### Method B — Manual credential plumbing (advanced)
+
+Ask Git which credential it resolves for each repo path:
+
+```bash
+# telco-homelab
+printf "protocol=https\nhost=github.com\npath=hervetchoffo/telco-homelab\nusername=hervetchoffo\n\n" \
+  | git credential fill
+
+# measure-dynamics-test
+printf "protocol=https\nhost=github.com\npath=hervetchoffo/measure-dynamics-test\nusername=hervetchoffo\n\n" \
+  | git credential fill
+```
+
+Expected output for each (token values will differ):
+
+```
+protocol=https
+host=github.com
+path=hervetchoffo/<repo>
+username=hervetchoffo
+password=github_pat_...
+```
+
+> **Note:** depending on your libsecret setup, `git credential fill` may prompt
+> interactively for the password rather than returning it silently. Both behaviours
+> are valid — what matters is that Git resolves the correct path for each repo.
+
+---
+
+## How it works internally
+
+| Setting | Without `useHttpPath` | With `useHttpPath=true` |
+|---|---|---|
+| Credential key | `https://github.com` | `https://github.com/hervetchoffo/<repo>` |
+| Repos sharing one token | All GitHub repos | None — each repo has its own entry |
+| libsecret entries | 1 | 1 per repo |
+
+---
+
+## PAT renewal
+
+Fine-grained PATs are set to expire after **90 days**. When a token expires:
+
+```bash
+# Erase the old entry for the relevant repo
+printf "protocol=https\nhost=github.com\npath=hervetchoffo/<repo>\nusername=hervetchoffo\n\n" \
+  | git credential reject
+
+# Trigger a new prompt to store the fresh token
+cd ~/Dropbox/Github/<repo>
+git fetch
+```
+
+---
+
+## Final configuration reference
+
+```bash
+git config --global --list | grep credential
+# credential.helper=/usr/share/doc/git/contrib/credential/libsecret/git-credential-libsecret
+# credential.usehttppath=true
+```
+
+```bash
+git remote -v   # inside each repo — username must be embedded in URL
+# origin  https://hervetchoffo@github.com/hervetchoffo/<repo>.git
+```


### PR DESCRIPTION
## Description

Adds a documentation guide for storing per-repository GitHub PATs
using libsecret on Linux Mint, with `credential.useHttpPath=true`
as the credential isolation mechanism.

Closes #1 

---

## Changes

- `docs/libsecret-credential-setup.md` — new guide (see details below)
- `CHANGELOG.md` — added `[1.1.1]` section and updated comparison links

---

## What this guide covers

| Section | Content |
|---|---|
| Context | Why host-only credential matching fails with multiple PATs |
| Problem | `credential.useHttpPath=true` as the correct solution |
| Step-by-step | libsecret setup, global config, per-repo PAT storage |
| Verification | `git fetch` (Method A) and `git credential fill` (Method B) |
| PAT renewal | Using `git credential reject` when tokens expire (90 days) |
| Reference | Final config snapshot for quick checks |

---

## Testing done

- [x] `git fetch` completes silently in `telco-homelab` (correct PAT used)
- [x] `git fetch` completes silently in `measure-dynamics-test` (correct PAT used)
- [x] Global config confirmed: `credential.usehttppath=true`
- [x] No credential helper set locally in either repo (global only)
- [x] Both PATs are fine-grained and scoped to their respective repo only

---

## Checklist

- [x] Branch named `fix/v1.1.1-<description>`
- [x] Commit message follows convention (`docs: ... — v1.1.1`)
- [x] `CHANGELOG.md` updated
- [x] No secrets committed
- [x] Linked to issue via `Closes #<issue-number>`

---

## Related

- Issue: #1 
- Milestone: `v1.1.0 — Initialize GitHub repository`
- SemVer: `v1.1.1` — documentation patch after `v1.1.0` stable release

---

## AI session reference

> This change was designed and documented with AI assistance.
> Full conversation not linked — contains a revoked credential.
> Context preserved in `docs/PROJECT_CONTEXT.md`.